### PR TITLE
get image size after it was loaded

### DIFF
--- a/public_html/js/sprite.js
+++ b/public_html/js/sprite.js
@@ -9,14 +9,16 @@ var Image = function( src )
 	var img_c = document.getElementById( "image_container" );
 	img_c.innerHTML += "<img id=\"img" + scount + "\" src=\"" + src + "\" >";
 	this.img = document.getElementById( "img" + scount );
+	
+	var self = this;
+	self.img.onload = function() {
+		self.width = self.img.clientWidth;
+		self.height = self.img.clientHeight;
+	};
+
 	scount++;
 	this.draw = function( context , area )
 	{
-		if( !this.width )
-		{
-			this.width = this.img.clientWidth;
-			this.height = this.img.clientHeight;
-		}
 		context.drawImage( this.img , area.ofx , area.ofy , area.ofw , area.ofh , area.x , area.y , area.w , area.h );
 	};
 };


### PR DESCRIPTION
when image of rooster is not cached by browser (e.g. first run), sprites are improperly scaled because of getting image size before it was loaded, and therefore having wrong width and height.
